### PR TITLE
fix: update postcss-config icon

### DIFF
--- a/webstorm-icons.json
+++ b/webstorm-icons.json
@@ -416,7 +416,7 @@
       "iconPath": "./icons/polymer.svg"
     },
     "postcss-config": {
-      "iconPath": "./icons/css.svg"
+      "iconPath": "./icons/javascript.svg"
     },
     "postcss": {
       "iconPath": "./icons/css.svg"


### PR DESCRIPTION
JetBrains products display postcss-config like js file, but the current configuration of webstorm-icons uses css icon